### PR TITLE
week2完了

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,5 @@
 export const metadata = {
-	title: "記事タイトル",
+	title: "説明ページ",
 	description: "このページは記事の内容を紹介しています。",
 	openGraph: {
 		title: "OGPタイトル",

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param children - 子要素
+ * @returns 管理者ページに共通するレイアウト
+ */
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<div style={{ backgroundColor: "#fdf6e3", padding: "2rem" }}>
+			<h2>🔐 管理画面</h2>
+			{children}
+		</div>
+	);
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export const metadata = {
+	title: "管理者用",
+};
+/**
+ * ページに表示させる文言を<h1>タグで囲んで返す関数
+ * @returns ページに表示させる文言を<h1>タグで囲んで返す
+ */
+export default function manager() {
+	return (
+		<div>
+			<h1>管理者用のページ</h1>
+			<Link href="/admin/setting">管理者の設定</Link>
+		</div>
+	);
+}

--- a/src/app/admin/setting/page.tsx
+++ b/src/app/admin/setting/page.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+	title: "管理者設定設定",
+};
+
+/**
+ * ページに表示させる文言を<h1>タグで囲んで返す関数
+ * @returns ページに表示させる文言を<h1>タグで囲んで返す
+ */
+export default function managerSetting() {
+	return (
+		<div>
+			<h1>管理者が設定を行うページ</h1>
+		</div>
+	);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,27 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { metadata } from "./about/page";
+
+export const metadata = {
+	title: "サンプルサイト",
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
 	return (
 		<html lang="ja">
 			<body>
-				<header>{metadata.title}</header>
-				{children}
-				<footer>
-					<Link href="/">ホームへ</Link>
+				<header style={{ padding: "1rem", background: "#eee" }}>
+					<h1>サンプルサイト</h1>
+					<Link href="/">ホーム</Link>
+					<span> </span>
+					<Link href="/memos">メモ一覧</Link>
+					<span> </span>
+					<Link href="/admin">管理者</Link>
+					<span> </span>
+					<Link href="/about">説明ページ</Link>
+				</header>
+				<main>{children}</main>
+				<footer style={{ padding: "1rem", background: "#eee" }}>
+					<p>© 2025 My Memo App</p>
 				</footer>
 			</body>
 		</html>

--- a/src/app/memos/id1/page.tsx
+++ b/src/app/memos/id1/page.tsx
@@ -1,3 +1,7 @@
+export const metadata = {
+	title: "メモ詳細ページ",
+};
+
 export default function Home() {
 	return (
 		<div>

--- a/src/app/memos/page.tsx
+++ b/src/app/memos/page.tsx
@@ -1,4 +1,9 @@
 import Link from "next/link";
+
+export const metadata = {
+	title: "メモ一覧",
+};
+
 export default function Home() {
 	return (
 		<div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
 
+export const metadata = {
+	title: "ホーム",
+};
+
 export default function HomePage() {
 	return (
 		<div>


### PR DESCRIPTION
対応内容

- layout.tsxをapp配下とadmin配下に設定し、サイト全体と管理者ページの配下に適応される共通レイアウト作成


エビデンス

- ホーム（親ページ）と管理者ページ（子ページ）にlayout.tsxの内容が設定されていることを確認
- ヘッダーのリンクから管理者ページに遷移できることを確認
![image](https://github.com/user-attachments/assets/1e079095-ae94-48ea-a904-9768d9fef008)
![image](https://github.com/user-attachments/assets/d9319fde-ebaa-4369-aee2-05b46fbec876)
![image](https://github.com/user-attachments/assets/2c3f6316-1000-4b6a-b264-cd152a6d8976)
